### PR TITLE
reworking directory search and index (plus random shuffle)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,9 @@
         <form action="/submit" method="post">
             <input type="submit" name="data" value="C is closer" class="button" id="selectC"></input>
         </form>
-
+    </div>
+    <div>
+        <p>Progess {{dir_index}}/{{total_dirs}}</p>
     </div>
 </div>
 <script>


### PR DESCRIPTION
- Add directory search to the global portion of the script instead of `index()`
- Add an index into the directories that increments on each call to index (this could be problematic as implemented, e.g. if user refreshes?)
- Adapt the directory search to fit the current data directory structure (explained in comment)
- Add a shuffle of all directories so order of examples is random
- Add a shuffle to the presentation of A, B, C examples on the webpage to user doesn't know the location of the correct answer. 
- Add a progress counter to track user progress